### PR TITLE
fixed IllegalArgumentException due to missing crowd-property

### DIFF
--- a/src/main/java/sonia/scm/crowd/CrowdAuthenticationHandler.java
+++ b/src/main/java/sonia/scm/crowd/CrowdAuthenticationHandler.java
@@ -237,6 +237,7 @@ public class CrowdAuthenticationHandler implements AuthenticationHandler, Config
         p.setProperty("application.name", config.getApplicationName());
         p.setProperty("application.password", config.getApplicationPassword());
         p.setProperty("session.validationinterval", config.getSessionValidationinterval());
+        p.setProperty("session.lastvalidation", config.getSessionLastvalidation());
         p.setProperty("cookie.tokenkey", config.getCookieTokenkey());
         p.setProperty("http.max.connections", config.getHttpMaxConnections());
         p.setProperty("http.timeout", config.getHttpTimeout());

--- a/src/main/java/sonia/scm/crowd/CrowdPluginConfig.java
+++ b/src/main/java/sonia/scm/crowd/CrowdPluginConfig.java
@@ -73,6 +73,10 @@ public class CrowdPluginConfig {
         return sessionValidationinterval;
     }
 
+    public String getSessionLastvalidation() {
+        return sessionLastvalidation;
+    }
+
     public String getCookieTokenkey() {
         return cookieTokenkey;
     }
@@ -101,6 +105,10 @@ public class CrowdPluginConfig {
 
     public void setSessionValidationinterval(String sessionValidationinterval) {
         this.sessionValidationinterval = sessionValidationinterval;
+    }
+
+    public void setSessionLastvalidation(String sessionLastvalidation) {
+        this.sessionLastvalidation = sessionLastvalidation;
     }
 
     public void setCookieTokenkey(String cookieTokenkey) {
@@ -137,6 +145,11 @@ public class CrowdPluginConfig {
      */
     @XmlElement(name = "sessionValidationinterval")
     private String sessionValidationinterval = "15";
+    /**
+     * The session key to use when storing a Date value of the user's last authentication. 
+     */
+    @XmlElement(name = "sessionLastvalidation")
+    private String sessionLastvalidation = "session.lastvalidation";
     /**
      * When using Crowd for single sign-on (SSO), you can specify the SSO cookie name for each application. Under the standard configuration, Crowd will use a single, default cookie name for all Crowd-connected applications. You can override the default with your own cookie name.
      * As well as allowing you to define the SSO cookie name, this feature also allows you to divide your applications into different SSO groups. For example, you might use one SSO token for your public websites and another for your internal websites.


### PR DESCRIPTION
When connecting SCM-Manager with the scm-crowd-plugin to Crowd 2.5.1 I received this error:

"ERROR sonia.scm.web.security.ChainAuthenticatonManager - setAttribute: name parameter cannot be null
java.lang.IllegalArgumentException: setAttribute: name parameter cannot be null"

This happend because Crowd expects the property "session.lastvalidation", which was not implemented.

This Commit adds the missing property and fixes the bug.

I didn't added GUI-elements for this configuration yet.
