### PR TITLE
Fix URL of Atlassian maven repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <repository>
             <id>atlassian-public-maven-repo</id>
             <name>atlassian public maven repository</name>
-            <url>https://maven.atlassian.com/content/repositories/public</url>
+            <url>https://packages.atlassian.com/maven-public-legacy</url>
         </repository>
     </repositories>
     <properties>


### PR DESCRIPTION
It looks like Atlassian has changed its repository URL. This PR fixes it in the maven pom.